### PR TITLE
method syntax dont need to be curried anymore

### DIFF
--- a/tests/b_parser.rs
+++ b/tests/b_parser.rs
@@ -1,0 +1,40 @@
+use lsts::tlc::TLC;
+
+#[test]
+fn parse_simplytyped() {
+   let mut tlc = TLC::new();
+   tlc.parse_str(None,"a;").unwrap();
+   tlc.parse_str(None,"a();").unwrap();
+   tlc.parse_str(None,"a(b);").unwrap();
+   tlc.parse_str(None,"a(b,c);").unwrap();
+   tlc.parse_str(None,"a.f;").unwrap();
+   tlc.parse_str(None,"a.f(b);").unwrap();
+   tlc.parse_str(None,"a.f(b,c);").unwrap();
+   tlc.parse_str(None,"let t: ?;").unwrap();
+   tlc.parse_str(None,"let t: T;").unwrap();
+   tlc.parse_str(None,"let t: ();").unwrap();
+   tlc.parse_str(None,"let t: (A);").unwrap();
+   tlc.parse_str(None,"let t: (A,B);").unwrap();
+   tlc.parse_str(None,"let t: T<A,B>;").unwrap();
+   tlc.parse_str(None,"let t: ()->A;").unwrap();
+   tlc.parse_str(None,"let t: A->B;").unwrap();
+   tlc.parse_str(None,"let t: (A)->B;").unwrap();
+   tlc.parse_str(None,"let t: (A,B)->C;").unwrap();
+   tlc.parse_str(None,"let a: A; let a: B;").unwrap();
+   tlc.parse_str(None,"let a: A; let b: A;").unwrap();
+   tlc.parse_str(None,"let f();").unwrap();
+   tlc.parse_str(None,"let f(a:A);").unwrap();
+   tlc.parse_str(None,"let f(a:A,b:B);").unwrap();
+   tlc.parse_str(None,"let f(a:A);").unwrap();
+   tlc.parse_str(None,"let f(a:A::Term);").unwrap();
+   tlc.parse_str(None,"let f():A;").unwrap();
+   tlc.parse_str(None,"let f()::Term;").unwrap();
+   tlc.parse_str(None,"type A;").unwrap();
+   tlc.parse_str(None,"forall :A,:B::C. (A,B);").unwrap();
+   tlc.parse_str(None,"forall :A,:B::C. (A,B) :: R;").unwrap();
+   tlc.parse_str(None,"forall :A,:B::C. (A,B) => C :: R;").unwrap();
+   tlc.parse_str(None,"{a; b;};").unwrap();
+
+   //Type Names, like Ab, are always valid constants, even without a prelude
+   tlc.parse_str(None,"let t: T[Ab];").unwrap();
+}

--- a/tests/c_l1.rs
+++ b/tests/c_l1.rs
@@ -26,6 +26,16 @@ fn l1_functions() {
 }
 
 #[test]
+fn l1_dot_functions() {
+   let mut tlc = TLC::new();
+   let l1 = tlc.import_file(None, "preludes/l1.tlc").unwrap();
+
+   tlc.check(Some(l1), "let .f(x:Integer): Integer = x; (1).f: Integer;").unwrap();
+   tlc.check(Some(l1), "let .f(x:Integer, y:Integer): Integer = x; (1).f(2): Integer;").unwrap();
+   tlc.check(Some(l1), "let .f(x:Integer, y:Integer, z:Integer): Integer = x; (1).f(2,3): Integer;").unwrap();
+}
+
+#[test]
 fn l1_reduce() {
    let mut tlc = TLC::new();
    let l1 = tlc.import_file(None, "preludes/l1.tlc").unwrap();

--- a/tests/tlc.rs
+++ b/tests/tlc.rs
@@ -1,42 +1,6 @@
 use lsts::tlc::TLC;
 
 #[test]
-fn parse_simplytyped() {
-   let mut tlc = TLC::new();
-   tlc.parse_str(None,"a;").unwrap();
-   tlc.parse_str(None,"a();").unwrap();
-   tlc.parse_str(None,"a(b);").unwrap();
-   tlc.parse_str(None,"a(b,c);").unwrap();
-   tlc.parse_str(None,"let t: ?;").unwrap();
-   tlc.parse_str(None,"let t: T;").unwrap();
-   tlc.parse_str(None,"let t: ();").unwrap();
-   tlc.parse_str(None,"let t: (A);").unwrap();
-   tlc.parse_str(None,"let t: (A,B);").unwrap();
-   tlc.parse_str(None,"let t: T<A,B>;").unwrap();
-   tlc.parse_str(None,"let t: ()->A;").unwrap();
-   tlc.parse_str(None,"let t: A->B;").unwrap();
-   tlc.parse_str(None,"let t: (A)->B;").unwrap();
-   tlc.parse_str(None,"let t: (A,B)->C;").unwrap();
-   tlc.parse_str(None,"let a: A; let a: B;").unwrap();
-   tlc.parse_str(None,"let a: A; let b: A;").unwrap();
-   tlc.parse_str(None,"let f();").unwrap();
-   tlc.parse_str(None,"let f(a:A);").unwrap();
-   tlc.parse_str(None,"let f(a:A,b:B);").unwrap();
-   tlc.parse_str(None,"let f(a:A);").unwrap();
-   tlc.parse_str(None,"let f(a:A::Term);").unwrap();
-   tlc.parse_str(None,"let f():A;").unwrap();
-   tlc.parse_str(None,"let f()::Term;").unwrap();
-   tlc.parse_str(None,"type A;").unwrap();
-   tlc.parse_str(None,"forall :A,:B::C. (A,B);").unwrap();
-   tlc.parse_str(None,"forall :A,:B::C. (A,B) :: R;").unwrap();
-   tlc.parse_str(None,"forall :A,:B::C. (A,B) => C :: R;").unwrap();
-   tlc.parse_str(None,"{a; b;};").unwrap();
-
-   //Type Names, like Ab, are always valid constants, even without a prelude
-   tlc.parse_str(None,"let t: T[Ab];").unwrap();
-}
-
-#[test]
 fn check_simplytyped() {
    let mut tlc = TLC::new();
 


### PR DESCRIPTION
## Describe your changes
Add syntax for methods that avoids unnecessary currying.

## Issue ticket number and link
#138 

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
