### PR TITLE
Support haskell-like infix syntax

### DIFF
--- a/examples/adder_infix.tlc
+++ b/examples/adder_infix.tlc
@@ -1,0 +1,5 @@
+import $"preludes/l1.tlc";
+
+let add(x: I64, y: I64): I64 = x + y;
+
+101 `add` 25 `add` 40;

--- a/src/token.rs
+++ b/src/token.rs
@@ -13,7 +13,7 @@ pub struct Span {
    pub offset_end: usize,
    pub linecol_start: (usize,usize),
    pub linecol_end: (usize,usize),
-}
+} 
 impl std::fmt::Debug for Span {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}:{},{}\n", self.filename, self.linecol_start.0, self.linecol_start.1)
@@ -87,6 +87,7 @@ pub enum Symbol {
    AndAlso,
    Typeof,
    At,
+   BackQuote,
    As,
    Match,
    Import,
@@ -146,6 +147,7 @@ impl std::fmt::Debug for Symbol {
            Symbol::BackSlash          => write!(f, "\\"),
            Symbol::Arrow              => write!(f, "->"),
            Symbol::At                 => write!(f, "@"),
+           Symbol::BackQuote          => write!(f, "`"),
 
            Symbol::LeftBracket        => write!(f, "["),
            Symbol::RightBracket       => write!(f, "]"),
@@ -244,6 +246,7 @@ impl TokenReader {
          [b',', ..] => Some((1,Symbol::Comma)),
          [b';', ..] => Some((1,Symbol::SemiColon)),
          [b'@', ..] => Some((1,Symbol::At)),
+         [b'`', ..] => Some((1,Symbol::BackQuote)),
          [b'\\', ..] => Some((1,Symbol::BackSlash)),
          [b'[', ..] => Some((1,Symbol::LeftBracket)),
          [b']', ..] => Some((1,Symbol::RightBracket)),

--- a/tests/a_tokenize.rs
+++ b/tests/a_tokenize.rs
@@ -4,7 +4,7 @@ use lsts::token::{Symbol,tokenize_string};
 #[test]
 fn tokenize_literals() {
    let mut tlc = TLC::new();
-   let mut tks = tokenize_string(&mut tlc, "[string]", r#"f"abc{d}{e:F}gh""#).unwrap();
+   let mut tks = tokenize_string(&mut tlc, "[string]", r#"f"abc{d}{e:F}gh"`"#).unwrap();
    assert_eq!( tks.take().unwrap().unwrap().symbol, Symbol::Literal );
    assert_eq!( tks.take().unwrap().unwrap().symbol, Symbol::LiteralS("abc".to_string()) );
    assert_eq!( tks.take().unwrap().unwrap().symbol, Symbol::LeftBrace );
@@ -17,5 +17,6 @@ fn tokenize_literals() {
    assert_eq!( tks.take().unwrap().unwrap().symbol, Symbol::RightBrace );
    assert_eq!( tks.take().unwrap().unwrap().symbol, Symbol::LiteralS("gh".to_string()) );
    assert_eq!( tks.take().unwrap().unwrap().symbol, Symbol::Literal );
+   assert_eq!( tks.take().unwrap().unwrap().symbol, Symbol::BackQuote );
    assert_eq!( tks.take().unwrap().unwrap().symbol, Symbol::EOF );
 }

--- a/tests/b_parser.rs
+++ b/tests/b_parser.rs
@@ -30,6 +30,7 @@ fn parse_simplytyped() {
    tlc.parse_str(None,"let f(a:A::Term);").unwrap();
    tlc.parse_str(None,"let f():A;").unwrap();
    tlc.parse_str(None,"let f()::Term;").unwrap();
+   tlc.parse_str(None,"a `f` b;").unwrap();
    tlc.parse_str(None,"type A;").unwrap();
    tlc.parse_str(None,"forall :A,:B::C. (A,B);").unwrap();
    tlc.parse_str(None,"forall :A,:B::C. (A,B) :: R;").unwrap();


### PR DESCRIPTION
## Describe your changes
Support infix syntax - putting the function name between its two arguments:
```rust
let add(x: I64, y: I64): I64 = x + y;

1 `add` 2; // output 3
```

## Issue ticket number and link
#153 

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
